### PR TITLE
Add missed package

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@types/cookie-parser": "^1.4.6",
     "@types/cors": "^2.8.17",
+    "@types/dotenv-safe": "^8.1.5",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/pg": "^8.11.0",

--- a/api/src/migrate.ts
+++ b/api/src/migrate.ts
@@ -1,4 +1,4 @@
-import "dotenv/config";
+import "dotenv-safe/config";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { db, pool } from "./db";
 import path from "path";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.17
+      '@types/dotenv-safe':
+        specifier: ^8.1.5
+        version: 8.1.5
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -914,6 +917,13 @@ packages:
       '@types/node': 20.11.10
     dev: true
 
+  /@types/dotenv-safe@8.1.5:
+    resolution: {integrity: sha512-E8z+Z0+yE8eEZ8BcMnb3I31fV3ROxobooqEDRBoQDAs4lb0c9X6Va6P6z+svj/USxw4R7TErcfEuW0tk7ymaPA==}
+    dependencies:
+      '@types/node': 20.11.10
+      dotenv: 8.6.0
+    dev: true
+
   /@types/express-serve-static-core@4.17.42:
     resolution: {integrity: sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==}
     dependencies:
@@ -1508,7 +1518,6 @@ packages:
   /dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
-    dev: false
 
   /downshift@8.3.1(react@18.2.0):
     resolution: {integrity: sha512-djPzjGfTSEjOsfmlur4onCV3Mtd6oGI+eOQIBNwoS7oEYTjPrxk6n+sJLmndT/KKwHvUyBSh3AFb64eHIFifTQ==}


### PR DESCRIPTION
"dotenv" is used in `api/src/migrate.ts`, but it is missing in `api/package.json`, which causes an error when you try to run migrations.